### PR TITLE
fix: increase ruby support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,5 +26,5 @@ Metrics/AbcSize:
   Max: 25
 
 AllCops:
-  TargetRubyVersion: 2.5.6
+  TargetRubyVersion: 2.5.1
   DisplayCopNames: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.5.6
+  - 2.5.1
   - 2.6.4
 before_install: gem install bundler -v 2.0.2
 before_script:

--- a/turtle.gemspec
+++ b/turtle.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['{lib}/**/*', 'CHANGELOG.md', 'MIT-LICENSE', 'README.md']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.5.6'
+  spec.required_ruby_version = '>= 2.5.1'
 
   spec.add_dependency 'aws-sns-configurator', '~> 0.2.0'
   spec.add_dependency 'aws-sqs-configurator', '~> 0.2.0'


### PR DESCRIPTION
O bulldog usa o 2.5.1 e talvez nao de para colocar o ruby 2.5.6 pois piora a perf da resposta das API's.