### PR TITLE
Remove Honeybadger as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,6 @@ act_as_notification model: 'order',
                     states: %i(pending completed),
                     state_column: :state,
                     actions: %i(created updated destroyed),
-                    rescue_errors: false,
-                    notify_rescued_error: false,
                     delayed: %i(created updated completed)
 ```
 
@@ -197,8 +195,6 @@ OrderEventSerializer.new(self).to_json
 | `states` | `[]` | false | The states name list. It will publish in a topic if the state was changed.  |
 | `state_column` | `:state` | false | The state column name. |
 | `actions` | `[]` | false | The actions name list. It will publish in a topic all times that the event happens. It allows the values `%i(created updated destroyed)`. |
-| `rescue_errors` | `false` | false | If true it allows to prevent errors. |
-| `notify_rescued_error` | `false` | false | If true it allows to notify when error is raised. |
 | `delayed` | `[]` | false | The events that you would like performing with delay. It requires DelayedJob. E.g: `%i(created updated completed)` |
 
 ## Contributing

--- a/lib/turtle.rb
+++ b/lib/turtle.rb
@@ -10,11 +10,6 @@ require 'turtle/event_notificator/event'
 require 'turtle/event_notificator/state'
 require 'turtle/event_notificator/action'
 require 'turtle/railtie' if defined?(Rails::Railtie) && defined?(Shoryuken)
-begin
-  require 'honeybadger'
-rescue LoadError
-  puts 'Error loading honeybadger lib, moving on...'
-end
 
 module Turtle
   class << self

--- a/lib/turtle.rb
+++ b/lib/turtle.rb
@@ -10,7 +10,11 @@ require 'turtle/event_notificator/event'
 require 'turtle/event_notificator/state'
 require 'turtle/event_notificator/action'
 require 'turtle/railtie' if defined?(Rails::Railtie) && defined?(Shoryuken)
-require 'honeybadger'
+begin
+  require 'honeybadger'
+rescue LoadError
+  puts 'Error loading honeybadger lib, moving on...'
+end
 
 module Turtle
   class << self

--- a/lib/turtle/event_notificator.rb
+++ b/lib/turtle/event_notificator.rb
@@ -167,9 +167,6 @@ module Turtle
           states: [],
           state_column: :state,
           actions: [],
-          rescue_errors: false,
-          notify_rescued_error: false,
-          continue_after_rescued_error: false,
           delayed: []
         }
       end

--- a/lib/turtle/event_notificator/notification.rb
+++ b/lib/turtle/event_notificator/notification.rb
@@ -16,19 +16,9 @@ module Turtle
       def publish!(payload, options)
         Logger.info("[Event Notification] Model: #{options[:model]} Event: #{@event}")
         Turtle.publish!(topic_options(options), payload, publish_options(options))
-      rescue StandardError => e
-        raise unless options[:rescue_errors]
-
-        notify_error!(e, payload, options)
       end
 
       private
-
-      def notify_error!(error, payload, options)
-        return unless options[:notify_rescued_error]
-
-        defined?(Honeybadger) && Honeybadger.notify(error, context: topic_options(options), parameters: payload.as_json)
-      end
 
       def publish_options(options)
         {

--- a/lib/turtle/event_notificator/notification.rb
+++ b/lib/turtle/event_notificator/notification.rb
@@ -27,7 +27,7 @@ module Turtle
       def notify_error!(error, payload, options)
         return unless options[:notify_rescued_error]
 
-        Honeybadger.notify(error, context: topic_options(options), parameters: payload.as_json)
+        defined?(Honeybadger) && Honeybadger.notify(error, context: topic_options(options), parameters: payload.as_json)
       end
 
       def publish_options(options)

--- a/spec/turtle/event_notificator/notification_spec.rb
+++ b/spec/turtle/event_notificator/notification_spec.rb
@@ -28,49 +28,12 @@ RSpec.describe Turtle::EventNotificator::Notification, type: :model do
     before { allow(notification).to receive(:as_json).and_return(event: notification.event) }
     subject { notification.publish!(notification, options) }
 
-    let(:honeybadger_class) do
-      Class.new do
-        def self.notify(error, context:, parameters:); end
-      end
-    end
-
-    before { stub_const('Honeybadger', honeybadger_class) }
-
     context 'when publish raise an error' do
       before { allow(Turtle).to receive(:publish!).and_raise(StandardError, 'Turtle publish error :(') }
 
-      context 'when rescue errors isnt enabled' do
-        let(:options) { { rescue_errors: false } }
-
-        it 'should raise an error' do
-          expect { subject }.to raise_error(StandardError, 'Turtle publish error :(')
-        end
-      end
-
-      context 'when rescue errors is enabled' do
-        let(:options) { { rescue_errors: true } }
-
-        it 'should raise an error' do
-          is_expected.to be_nil
-        end
-
-        context 'when notify rescued error isnt enabled' do
-          let(:options) { { rescue_errors: true, notify_rescued_error: false } }
-
-          it 'shouldnt notify through' do
-            expect(Honeybadger).not_to receive(:notify)
-            subject
-          end
-        end
-
-        context 'when notify rescued error is enabled' do
-          let(:options) { { rescue_errors: true, notify_rescued_error: true } }
-
-          it 'shouldnt notify through' do
-            expect(Honeybadger).to receive(:notify).once
-            subject
-          end
-        end
+      let(:options) { {} }
+      it 'should raise an error' do
+        expect { subject }.to raise_error(StandardError, 'Turtle publish error :(')
       end
     end
 

--- a/spec/turtle/event_notificator/notification_spec.rb
+++ b/spec/turtle/event_notificator/notification_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe Turtle::EventNotificator::Notification, type: :model do
     before { allow(notification).to receive(:as_json).and_return(event: notification.event) }
     subject { notification.publish!(notification, options) }
 
+    let(:honeybadger_class) do
+      Class.new do
+        def self.notify(error, context:, parameters:); end
+      end
+    end
+
+    before { stub_const('Honeybadger', honeybadger_class) }
+
     context 'when publish raise an error' do
       before { allow(Turtle).to receive(:publish!).and_raise(StandardError, 'Turtle publish error :(') }
 
@@ -79,7 +87,7 @@ RSpec.describe Turtle::EventNotificator::Notification, type: :model do
           expect(Turtle).to receive(:publish!).with(
             { name: 'event_order', prefix: 'turtle', environment: 'production', suffix: notification.event },
             notification,
-            delayed: nil, event: nil, model: nil
+            { delayed: nil, event: nil, model: nil }
           ).once
           subject
         end
@@ -92,7 +100,7 @@ RSpec.describe Turtle::EventNotificator::Notification, type: :model do
           expect(Turtle).to receive(:publish!).with(
             { name: 'event_order', prefix: 'turtle', environment: 'production', suffix: notification.event },
             notification,
-            delayed: :completed, event: nil, model: nil
+            { delayed: :completed, event: nil, model: nil }
           ).once
           subject
         end
@@ -105,7 +113,7 @@ RSpec.describe Turtle::EventNotificator::Notification, type: :model do
           expect(Turtle).to receive(:publish!).with(
             { name: 'event_order', prefix: 'turtle', environment: 'production', suffix: notification.event },
             notification,
-            delayed: nil, event: false, model: false
+            { delayed: nil, event: false, model: false }
           ).once
           subject
         end
@@ -118,7 +126,7 @@ RSpec.describe Turtle::EventNotificator::Notification, type: :model do
           expect(Turtle).to receive(:publish!).with(
             { name: 'event_order', prefix: 'turtle', environment: 'production', suffix: notification.event },
             notification,
-            delayed: nil, event: :completed, model: 'order'
+            { delayed: nil, event: :completed, model: 'order' }
           ).once
           subject
         end

--- a/spec/turtle/event_notificator_spec.rb
+++ b/spec/turtle/event_notificator_spec.rb
@@ -95,8 +95,6 @@ RSpec.describe Turtle::EventNotificator, type: :module do
               states: %i[pending completed],
               state_column: :state,
               actions: %i[created updated destroyed],
-              rescue_errors: false,
-              notify_rescued_error: false,
               delayed: %i[created updated destroyed]
             }
           end
@@ -145,8 +143,6 @@ RSpec.describe Turtle::EventNotificator, type: :module do
           states: %i[pending completed],
           state_column: :state,
           actions: %i[create update destroy],
-          rescue_errors: false,
-          notify_rescued_error: false,
           delayed: %i[created updated destroyed]
         )
       end
@@ -158,9 +154,6 @@ RSpec.describe Turtle::EventNotificator, type: :module do
           state_column: :state,
           serializer_options: {},
           actions: %i[create update destroy],
-          rescue_errors: false,
-          notify_rescued_error: false,
-          continue_after_rescued_error: false,
           delayed: %i[created updated destroyed],
           model: 'order',
           serializer: OrderInstanceMethods
@@ -183,8 +176,6 @@ RSpec.describe Turtle::EventNotificator, type: :module do
           states: %i[pending completed],
           state_column: :state,
           actions: %i[created updated destroyed],
-          rescue_errors: false,
-          notify_rescued_error: false,
           delayed: %i[created updated destroyed]
         )
         subject
@@ -227,8 +218,6 @@ RSpec.describe Turtle::EventNotificator, type: :module do
           states: %i[pending completed],
           state_column: :state,
           actions: %i[created updated],
-          rescue_errors: false,
-          notify_rescued_error: false,
           delayed: %i[created updated destroyed]
         )
         order.event_notificator_before_callback!(:update)
@@ -289,8 +278,6 @@ RSpec.describe Turtle::EventNotificator, type: :module do
           states: %i[pending completed],
           state_column: :state,
           actions: %i[created updated destroyed],
-          rescue_errors: false,
-          notify_rescued_error: false,
           delayed: %i[created updated destroyed]
         )
         order.event_notificator_before_callback!(:update)
@@ -365,8 +352,6 @@ RSpec.describe Turtle::EventNotificator, type: :module do
           states: %i[pending completed],
           state_column: :state,
           actions: %i[created updated destroyed],
-          rescue_errors: false,
-          notify_rescued_error: false,
           delayed: %i[created updated destroyed]
         )
       end

--- a/turtle.gemspec
+++ b/turtle.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aws-sns-configurator'
   spec.add_dependency 'aws-sqs-configurator'
-  spec.add_dependency 'honeybadger'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'factory_bot'


### PR DESCRIPTION
- Remove honeybadger as dependency
- Remove option to rescue errors inside notifier (app obligation to handle these errors)
