### PR TITLE
Turtle autosuficiente

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,24 @@
 
 source 'https://rubygems.org'
 
-gem 'aws-sns-configurator', github: 'petlove/aws-sns-configurator'
-gem 'aws-sqs-configurator', github: 'petlove/aws-sqs-configurator'
+gem 'aws-sdk-core', '~> 3'
+gem 'aws-sdk-sns', '>= 1.18.0'
+
+group :development, :test do
+  gem 'awesome_print'
+  gem 'dotenv'
+  gem 'pry'
+  gem 'rubocop'
+  gem 'rubocop-performance'
+end
+
+group :test do
+  gem 'rspec'
+  gem 'simplecov', require: false
+  gem 'simplecov-console'
+  gem 'simplecov-summary'
+  gem 'vcr'
+  gem 'webmock'
+end
 
 gemspec

--- a/turtle.gemspec
+++ b/turtle.gemspec
@@ -19,9 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.5.1'
 
-  spec.add_dependency 'aws-sns-configurator'
-  spec.add_dependency 'aws-sqs-configurator'
-
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'factory_bot'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
Stops using aws-sns-configurator and aws-sqs-configurator, concentrating everything in turtle itself.