### PR TITLE
fix error ArgumentError: no receiver given

### DIFF
--- a/lib/turtle/event_notificator.rb
+++ b/lib/turtle/event_notificator.rb
@@ -42,7 +42,7 @@ module Turtle
       end
 
       def build_event_notificator_notify!
-        send(:after_commit, ->(obj) { obj.event_notificator_notify! })
+        send(:after_commit, ->(obj) { obj.event_notificator_notify! }) # rubocop:disable Style/SymbolProc
       end
 
       def build_event_notificator_before_callback!
@@ -58,7 +58,7 @@ module Turtle
       end
 
       def build_event_notificator_after_touch_callback!
-        send(:after_touch, ->(obj) { obj.save })
+        send(:after_touch, ->(obj) { obj.save }) # rubocop:disable Style/SymbolProc
       end
 
       def build_event_notificator_options!(options)

--- a/lib/turtle/event_notificator.rb
+++ b/lib/turtle/event_notificator.rb
@@ -42,7 +42,9 @@ module Turtle
       end
 
       def build_event_notificator_notify!
-        send(:after_commit, lambda(&:event_notificator_notify!))
+        send(:after_commit, lambda { |obj|
+          obj.event_notificator_notify!
+        })
       end
 
       def build_event_notificator_before_callback!
@@ -58,7 +60,9 @@ module Turtle
       end
 
       def build_event_notificator_after_touch_callback!
-        send(:after_touch, lambda(&:save))
+        send(:after_touch, lambda { |obj|
+          obj.save
+        })
       end
 
       def build_event_notificator_options!(options)

--- a/lib/turtle/event_notificator.rb
+++ b/lib/turtle/event_notificator.rb
@@ -42,9 +42,7 @@ module Turtle
       end
 
       def build_event_notificator_notify!
-        send(:after_commit, lambda { |obj|
-          obj.event_notificator_notify!
-        })
+        send(:after_commit, ->(obj) { obj.event_notificator_notify! })
       end
 
       def build_event_notificator_before_callback!
@@ -60,9 +58,7 @@ module Turtle
       end
 
       def build_event_notificator_after_touch_callback!
-        send(:after_touch, lambda { |obj|
-          obj.save
-        })
+        send(:after_touch, ->(obj) { obj.save })
       end
 
       def build_event_notificator_options!(options)


### PR DESCRIPTION
Quando atualizei a gem no dog, começou a dar o seguinte erro:

https://app.honeybadger.io/projects/64400/faults/117748646

PR: https://github.com/petlove/dog/pull/1222/

não entendi muito bem, mas parece que em algum momento o obj está nil, e da maneira que era antes, ele tentava chamar o método no objeto `nil`

`send(:after_commit, lambda(&:event_notificator_notify!))`


da forma que está agora, ele só chama quando não está nil
```
        send(:after_commit, lambda { |obj|
          obj.event_notificator_notify!
        })
```
