### PR TITLE
chore: relax aws-sdk-core and aws-sdk-sqs version constraints

### DIFF
--- a/turtle.gemspec
+++ b/turtle.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.5.1'
 
-  spec.add_dependency 'aws-sdk-core', '< 3.192.0'
+  spec.add_dependency 'aws-sdk-core', '~> 3'
   spec.add_dependency 'aws-sdk-sns', '>= 1.18.0'
-  spec.add_dependency 'aws-sdk-sqs', '>= 1.18', '< 1.35'
+  spec.add_dependency 'aws-sdk-sqs', '>= 1.18'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'factory_bot'


### PR DESCRIPTION
## Summary

- Remove upper bound `< 3.192.0` from `aws-sdk-core` dependency (now `~> 3`)
- Remove upper bound `< 1.35` from `aws-sdk-sqs` dependency (now `>= 1.18`)

## Why

The restrictive constraints on `aws-sdk-core` and `aws-sdk-sqs` are preventing other projects from updating `aws-sdk-s3` to `>= 1.208.0`, which is required to fix 

- `aws-sdk-s3 >= 1.208.0` requires `aws-sdk-core >= 3.234.0`
- `turtle` pins `aws-sdk-core < 3.192.0`, making the two incompatible

There is no functional difference between `aws-sdk-sqs` 1.34 and 1.35 that would affect `turtle` — both versions share the same dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)